### PR TITLE
Fix ESLint-error occuring in Ember 2.12.

### DIFF
--- a/addon/components/simple-mde.js
+++ b/addon/components/simple-mde.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import layout from '../templates/components/simple-mde';
 
+/*global SimpleMDE*/
+
 export default Ember.TextArea.extend({
   layout,
 


### PR DESCRIPTION
Fix ESLint-error occuring in Ember 2.12. 
Now global-var SimpleMDE is explicitly mentioned in a /*global ...*/ comment.