### PR TITLE
Removes`simplemde` bower dependency in favor of pulling `simplemde` from NPM.

### DIFF
--- a/blueprints/ember-simplemde/index.js
+++ b/blueprints/ember-simplemde/index.js
@@ -1,10 +1,5 @@
 /*jshint node:true*/
 module.exports = {
   description: 'bower dependencies for ember-simplemde',
-
-  normalizeEntityName: function() {},
-
-  afterInstall: function(options) {
-    return this.addBowerPackageToProject('simplemde', '^1.11.2');
-  }
+  normalizeEntityName: function() {}
 };

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "ember-simplemde",
   "dependencies": {
     "ember": "~2.9.0",
-    "ember-cli-shims": "0.1.3",
-    "simplemde": "^1.11.2"
+    "ember-cli-shims": "0.1.3"
   }
 }

--- a/index.js
+++ b/index.js
@@ -10,15 +10,15 @@ module.exports = {
     return path.join(__dirname, 'blueprints');
   },
 
-  included: function(app, parentAddon) {
-    this._super.included(...arguments);
-    while (app.app) {
-      app = app.app;
+  options: {
+    nodeAssets: {
+      'simplemde': {
+        srcDir: 'dist',
+        import: [
+          'simplemde.min.js',
+          'simplemde.min.css'
+        ],
+      },
     }
-
-    let target = parentAddon || app;
-
-    target.import(`${target.bowerDirectory}/simplemde/dist/simplemde.min.js`);
-    target.import(`${target.bowerDirectory}/simplemde/dist/simplemde.min.css`);
-  }
+  },
 };

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
-    "ember-cli-htmlbars": "1.2.0"
+    "ember-cli-htmlbars": "1.2.0",
+    "simplemde": "^1.11.2",
+    "ember-cli-node-assets": "0.2.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Just started using this at work. Great work on this ember-addon. We are trying to remove bower from our projects at work, hence this PR. The library we added that does static asset loading from npm called [`ember-cli-node-assets`](https://github.com/dfreeman/ember-cli-node-assets) is really well supported and stable. It has provided an easy way to remove bower deps from many addons we use.

* Removes `simplemde` dependency from bower.json and from the blueprint's `afterInstall` hooks `addBowerPackageToProject` method.
* Adds `simplemde` npm dependency to `package.json`
* Adds `ember-cli-node-assets` dependency to `package.json,` this library handles loading static assets pulled from NPM
* Removes `included` hook from `index.js` in favor of loading the static assets with `ember-cli-node-assets`