### PR TITLE
Adds ability to pass options to simpleMDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,28 @@ You can pass options through to the simpleMDE instance in two ways.
     };
   ```
 
+  Note: If you are customizing the simpleMDE toolbar options from the consuming apps config, simpleMDE needs you to pass toolbar option action handlers as function references. In ember configs, we can only express these function references as strings. Ember-simplemde has a mechanism in place to unpack these strings as function references against the window.SimpleMDE global. So, if you are expressing a custom toolbar option from your consuming apps config, pass the toolbar action handlers as strings.
+
+  For example, the action handler below will be unpacked against the window as `window['SimpleMDE']['toggleBold']` to obtain the original function reference.
+
+  ```
+  module.exports = function(environment) {
+    var ENV = {
+      ...
+      simpleMDE: {
+        toolbar: [
+          {
+            name: 'bold',
+            action: 'SimpleMDE.toggleBold',
+            className: 'fa fa-bold',
+            title: 'Bold'
+          }
+        ]
+      },
+      ...
+    };
+  ```
+
 * You can pass instance options via the simple-mde components `options` attribute. The options attribute will overwrite global options via `ember.assign` so if you want instance options to squash global options you can use this. An example of this is in the `tests/dummy/app/application.hbs` and the corresponding application controller.
 
   ```

--- a/README.md
+++ b/README.md
@@ -32,50 +32,58 @@ A wrapper around the SimpleMDE editor for use in ember-cli projects, it provides
 
 ## Passing options to simpleMDE
 
-You can pass options through to the simpleMDE instance in two ways.
+ember-simplemde supports all options that SimpleMDE supports.
 
 [full list of all simpleMde options](https://github.com/NextStepWebs/simplemde-markdown-editor#configuration)
 
-* You can pass global options that will be applied to all editors via the consuming apps `config/environment` with a property called `simpleMDE`. For example, if you wanted to remove the toolbar from all instances:
+You can pass options through to the simpleMDE instance in two ways.
 
-  ```
-  module.exports = function(environment) {
-    var ENV = {
-      ...
-      simpleMDE: {
-        toolbar: false
-      },
-      ...
-    };
-  ```
+#### Define Options in your ember config that will be applied to all simpleMDE instances
+You can pass global options that will be applied to all editors via the consuming apps `config/environment` with a property called `simpleMDE`. For example, if you wanted to remove the toolbar from all instances:
 
-  Note: If you are customizing the simpleMDE toolbar options from the consuming apps config, simpleMDE needs you to pass toolbar option action handlers as function references. In ember configs, we can only express these function references as strings. Ember-simplemde has a mechanism in place to unpack these strings as function references against the window.SimpleMDE global. So, if you are expressing a custom toolbar option from your consuming apps config, pass the toolbar action handlers as strings.
+```
+module.exports = function(environment) {
+  var ENV = {
+    ...
+    simpleMDE: {
+      toolbar: false,
+      ... any simpleMDE options go here
+    },
+    ...
+  };
+```
 
-  For example, the action handler below will be unpacked against the window as `window['SimpleMDE']['toggleBold']` to obtain the original function reference.
+Note on toolbar options action handlers: If you are customizing the simpleMDE toolbar options from the consuming apps config, simpleMDE needs you to pass toolbar option action handlers as function references. In ember configs, we can only express these function references as strings. Ember-simplemde has a mechanism in place to unpack these strings as function references against the window.SimpleMDE global. So, if you are expressing a custom toolbar option from your consuming apps config, pass the toolbar action handlers as strings.  If you are passing options to the instance and not using your ember/config you can use function reference's/definitions like normal.
 
-  ```
-  module.exports = function(environment) {
-    var ENV = {
-      ...
-      simpleMDE: {
-        toolbar: [
-          {
-            name: 'bold',
-            action: 'SimpleMDE.toggleBold',
-            className: 'fa fa-bold',
-            title: 'Bold'
-          }
-        ]
-      },
-      ...
-    };
-  ```
+For example, the action handler below will be unpacked against the window as
+```
+window['SimpleMDE']['toggleBold']
+```
 
-* You can pass instance options via the simple-mde components `options` attribute. The options attribute will overwrite global options via `ember.assign` so if you want instance options to squash global options you can use this. An example of this is in the `tests/dummy/app/application.hbs` and the corresponding application controller.
+```
+module.exports = function(environment) {
+  var ENV = {
+    ...
+    simpleMDE: {
+      toolbar: [
+        {
+          name: 'bold',
+          action: 'SimpleMDE.toggleBold',
+          className: 'fa fa-bold',
+          title: 'Bold'
+        }
+      ]
+    },
+    ...
+  };
+```
 
-  ```
-  {{simple-mde value=value options=simpleMdeOptions}}
-  ```
+#### Define options on the individual editor instance
+You can pass instance options via the simple-mde components `options` attribute. The options attribute will overwrite global options via `ember.assign` so if you want instance options to squash global options you can use this. An example of this is in the `tests/dummy/app/application.hbs` and the corresponding application controller.
+
+```
+{{simple-mde value=value options=simpleMdeOptions}}
+```
 
 Note: This options parameter is NOT watched. Changing it during runtime will not change the instance properties.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,36 @@ A wrapper around the SimpleMDE editor for use in ember-cli projects, it provides
 
 * Use the helper like this:
 
-  ```{{simple-mde-preview theValue}}```
+  ```
+  {{simple-mde-preview theValue}}
+  ```
+
+## Passing options to simpleMDE
+
+You can pass options through to the simpleMDE instance in two ways.
+
+[full list of all simpleMde options](https://github.com/NextStepWebs/simplemde-markdown-editor#configuration)
+
+* You can pass global options that will be applied to all editors via the consuming apps `config/environment` with a property called `simpleMDE`. For example, if you wanted to remove the toolbar from all instances:
+
+  ```
+  module.exports = function(environment) {
+    var ENV = {
+      ...
+      simpleMDE: {
+        toolbar: false
+      },
+      ...
+    };
+  ```
+
+* You can pass instance options via the simple-mde components `options` attribute. The options attribute will overwrite global options via `ember.assign` so if you want instance options to squash global options you can use this. An example of this is in the `tests/dummy/app/application.hbs` and the corresponding application controller.
+
+  ```
+  {{simple-mde value=value options=simpleMdeOptions}}
+  ```
+
+Note: This options parameter is NOT watched. Changing it during runtime will not change the instance properties.
 
 ## Installation
 
@@ -51,4 +80,3 @@ A wrapper around the SimpleMDE editor for use in ember-cli projects, it provides
 * `ember build`
 
 For more information on using ember-cli, visit [http://ember-cli.com/](http://ember-cli.com/).
-

--- a/addon/components/simple-mde.js
+++ b/addon/components/simple-mde.js
@@ -62,7 +62,7 @@ export default Ember.TextArea.extend({
       builtOptions.toolbar.forEach(this.unpackToolbarOption);
     }
 
-    return builtOptions
+    return builtOptions;
   }),
 
   /**

--- a/addon/components/simple-mde.js
+++ b/addon/components/simple-mde.js
@@ -1,6 +1,12 @@
 import Ember from 'ember';
 import layout from '../templates/components/simple-mde';
 
+const {
+  assign,
+  get,
+  testing,
+} = Ember;
+
 /*global SimpleMDE*/
 
 export default Ember.TextArea.extend({
@@ -19,14 +25,37 @@ export default Ember.TextArea.extend({
   change: null,
 
   /**
+  * instance options to pass to simpleMDE
+  */
+  options: {},
+
+  /**
+  * default simpleMDE options
+  */
+  defaultSimpleMdeOptions: Ember.computed(function () {
+    return {
+      showIcons: ['table'],
+    };
+  }),
+
+  /**
+  * global options defined in consuming apps config
+  */
+  globalSimpleMdeOptions: Ember.computed(function() {
+    if(testing) {
+      return {};
+    } else {
+      return get(Ember.getOwner(this).resolveRegistration('config:environment'), 'simpleMDE') || {};
+    }
+  }),
+
+  /**
    * @method
    * @private
    * get the list of options to pass to init the SimpleMDE instance
    */
   buildSimpleMDEOptions: Ember.computed(function () {
-    return {
-      showIcons: ['table']
-    };
+    return assign({}, this.get('defaultSimpleMdeOptions'), this.get('globalSimpleMdeOptions'), this.get('options'));
   }),
 
   /**

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "1.2.0",
     "simplemde": "^1.11.2",
-    "ember-cli-node-assets": "0.2.2"
+    "ember-cli-node-assets": "0.2.2",
+    "ember-assign-polyfill": "2.0.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -4,6 +4,9 @@ export default Ember.Controller.extend({
   newValue: null,
   value: "This is a test with **bold** and _italic_",
 
+  simpleMdeOptions: {
+    toolbar: false
+  },
 
   actions: {
     showNewValue (value) {

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -4,8 +4,33 @@ export default Ember.Controller.extend({
   newValue: null,
   value: "This is a test with **bold** and _italic_",
 
-  simpleMdeOptions: {
+  simpleMdeOptionsWithNoToolbar: {
     toolbar: false
+  },
+
+  simpleMdeOptionsWithCustomToolbar: {
+    toolbar: [
+      {
+        name: 'bold',
+        action: 'SimpleMDE.toggleBold',
+        className: 'fa fa-bold',
+        title: 'Bold'
+      }
+    ]
+  },
+
+  simpleMdeOptionsWithCustomToolbarFunctionRefHandler: {
+    toolbar: [
+      {
+        name: 'custom',
+        action: function(editor) {
+          console.log(editor);
+          // Do custom stuff here.
+        },
+        className: 'fa fa-bath',
+        title: 'Custom'
+      }
+    ]
   },
 
   actions: {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -13,4 +13,11 @@
 {{textarea value=value}}
 
 <h2>Passing options to the simpleMDE instance</h2>
-{{simple-mde value=value options=simpleMdeOptions}}
+<h3>Disable the toolbar</h3>
+{{simple-mde value=value options=simpleMdeOptionsWithNoToolbar}}
+
+<h3>Use the built in Bold action handler</h3>
+{{simple-mde value=value options=simpleMdeOptionsWithCustomToolbar}}
+
+<h3>Create a custom toolbar option with a function reference handler</h3>
+{{simple-mde value=value options=simpleMdeOptionsWithCustomToolbarFunctionRefHandler}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -11,3 +11,6 @@
 {{simple-mde-preview value}}
 <p> link a textarea </p>
 {{textarea value=value}}
+
+<h2>Passing options to the simpleMDE instance</h2>
+{{simple-mde value=value options=simpleMdeOptions}}

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -17,6 +17,8 @@ module.exports = function(environment) {
       }
     },
 
+    simpleMDE: {},
+
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created

--- a/tests/integration/components/simple-mde-test.js
+++ b/tests/integration/components/simple-mde-test.js
@@ -32,6 +32,18 @@ test('it renders the new value passed', function(assert) {
   assert.ok(this.$().text().trim().indexOf('Only text') >= 0);
 });
 
+test('it respects options passed to simpleMDE via component options param', function(assert) {
+  this.set('markdownValue', 'This is a **bold** text');
+  this.set('simpleMdeOptions', {
+    toolbar: false
+  });
+  this.render(hbs`{{simple-mde value=markdownValue options=simpleMdeOptions}}`);
+
+  assert.ok(this.$().text().trim().indexOf('This is a **bold** text') >= 0);
+
+  assert.ok(this.$().find('.editor-toolbar').length === 0);
+});
+
 /*
 test('buble change action back', function(assert) {
   let self = this;


### PR DESCRIPTION
* Updates readme with examples and instructions around options
* Adds new public options parameter to the simple-mde component
* Updates simple-mde component to merge instance options into global options into default (internal) simple-mde options before creating the instance
* Adds example to the dummy app to show usage of instance options
* Adds integration test for disabling the simple-mde toolbar via options parameter

Update:
* Adds ember-assign-polyfill as travis.yml is attempting to support versions less than 2.4